### PR TITLE
+ Lowered rate of false positives by writing a nice little script that will remove comments and quotes.

### DIFF
--- a/fix-globals.php
+++ b/fix-globals.php
@@ -15,7 +15,9 @@
 		- Fix duplicate and undeclared globals, instead of just unused globals.
 */
 
+$script_name = basename(__FILE__);
 $root = dirname(__FILE__);
+set_time_limit(300);
 
 echo '<!DOCTYPE html><html><style>
 	body { font-family: Arial, sans-serif; color: #666; }
@@ -30,14 +32,19 @@ echo '<!DOCTYPE html><html><style>
 	.unused     { background: linear-gradient(to right, #bea, #fff 30px); }
 </style><body>
 
-<h1>', basename(__FILE__), '</h1>
+<h1>', $script_name, '</h1>
+<div>By Nao (Wedge.org)</div>
+<hr>
 
 <p>
 	This script will list all PHP files in the <samp>', $root, '</samp> folder that have duplicate, unneeded global declarations or undeclared globals.
-	Credits: Nao (Wedge.org)
 <p>
 <p>
-	Add <kbd>?fixme</kbd> to the URL to allow the script to fix all files for you, except for potential false-positives and duplicate or undeclared globals.
+	Add <kbd><a href="', $script_name, '?noclean">?noclean</a></kbd> to view a quick, dirty list of results that may generate more false positives.
+	<br>
+	Add <kbd><a href="', $script_name, '?ignorefp">?ignorefp</a></kbd> to list only strong suspects; potential false positives will be ignored.
+	<br>
+	Add <kbd>?fixme</kbd> to the URL to allow the script to fix all files for you, except for potential false-positives and duplicate or undeclared globals. Still, beware!
 </p>
 
 <ol>';
@@ -47,6 +54,7 @@ find_global_problems(array(
 	'$txt',
 	'$context',
 	'$settings',
+	'$modSettings',
 	'$options',
 	'$board',
 	'$topic',
@@ -63,13 +71,13 @@ function find_global_problems($real_globals = array(), $dir = '')
 {
 	global $root;
 
-	$i = 0;
 	$old_file = '';
 	$dir = $dir ? $dir : $root;
 	$files = scandir($dir);
+
 	foreach ($files as $file)
 	{
-		if ($file == '.' || $file == '..' || $file == '.git' || $file == 'other')
+		if ($file == '.' || $file == '..' || $file == '.git' || $file == 'other' || $file == 'cache')
 			continue;
 		if (is_dir($dir . '/' . $file))
 		{
@@ -79,8 +87,24 @@ function find_global_problems($real_globals = array(), $dir = '')
 		if (substr($file, -4) != '.php')
 			continue;
 
-		$php = file_get_contents($dir . '/' . $file);
-		preg_match_all('~[\r\n](\t*)(?:private|protected|public|static| )*function ([\w]+)[^}\r\n]+[\r\n]+\1(.*?)[\r\n]+\1}~s', $php, $matches);
+		$php = $real_php = file_get_contents($dir . '/' . $file);
+
+		// Remove comments, quotes and double quotes from the string.
+		// This makes the script about 5x to 10x slower, so if you just need a quick check, add the ?noclean parameter.
+		// A few alternative ways to remove these through regex, but they won't work together:
+		// http://ideone.com/rLP1nq
+		// http://blog.stevenlevithan.com/archives/match-quoted-string
+		if (!isset($_GET['noclean']) || isset($_GET['fixme']))
+			$php = clean_me_up($php);
+
+		// Detect named functions and class methods.
+		// !! @todo: detect anonymous functions.
+		preg_match_all('~[\r\n](\t*)(?:private|protected|public|static| )*?function (\w+)([^}\r\n]+[\r\n]+\1.*?)[\r\n]+\1}~s', $php, $matches);
+
+		// !! @todo: test this!
+		if (isset($_GET['fixme']))
+			preg_match_all('~[\r\n](\t*)(?:private|protected|public|static| )*?function (\w+)([^}\r\n]+[\r\n]+\1.*?)[\r\n]+\1}~s', $real_php, $real_matches);
+
 		foreach ($matches[3] as $key => $val)
 		{
 			preg_match_all('~[\r\n{][\t ]*global (\$[^;]+);~', $val, $globs);
@@ -93,7 +117,7 @@ function find_global_problems($real_globals = array(), $dir = '')
 				{
 					$is_new = $file != $old_file;
 					$old_file = $file;
-					echo '<li class="duplicates', $is_new ? ' new' : '', '">Found duplicate globals in ', $file, ':', $matches[2][$key], ' -- ', $find_dupes, '</li>';
+					echo '<li class="duplicates', $is_new ? ' new' : '', '">Found duplicate globals in <span>', str_replace($root, '', $dir), '/<span class="file">', $file, '</span></span> (', $matches[2][$key], ') -- ', $find_dupes, '</li>';
 				}
 			}
 
@@ -106,43 +130,50 @@ function find_global_problems($real_globals = array(), $dir = '')
 				{
 					if (!preg_match('~\\' . $test_me . '[^a-zA-Z_]~', $val))
 					{
-						$is_new = $file != $old_file;
-						$old_file = $file;
-						$func_line = substr_count(substr($php, 0, strpos($php, $matches[0][$key])), "\n");
-						$glob_line = substr_count(substr($matches[3][$key], 0, strpos($matches[3][$key], $test_me)), "\n");
-						echo '<li class="unused', $is_new ? ' new' : '', '">Unused global in <span>', str_replace($root, '', $dir), '/<span class="file">', $file, ':', $func_line + $glob_line + 3, '</span></span> (', $matches[2][$key], ') -- <span>', $test_me, '</span>';
-
 						$ex = $matches[0][$key];
-						if ((($r = '$$') && strpos($ex, '$$') !== false) ||
+						$probably_false_positive =
+							((($r = '$$') && strpos($ex, '$$') !== false) ||
 							(($r = '${$') && strpos($ex, '${$') !== false) ||
 							(($r = 'include()') && strpos($ex, 'include(') !== false) ||
 							(($r = 'require()') && strpos($ex, 'require(') !== false) ||
 							(($r = 'include_once()') && strpos($ex, 'include_once') !== false) ||
-							(($r = 'require_once()') && strpos($ex, 'require_once') !== false))
+							(($r = 'require_once()') && strpos($ex, 'require_once') !== false));
+
+						if (!$probably_false_positive || !isset($_GET['ignorefp']))
 						{
-							if (!isset($_GET['fixme']))
-								echo '<br><em>The line above might be a false positive (<span>', $r, '</span>); it will be skipped during automatic fixes.</em></li>';
-							else
-								echo '<br><em>Skipping fix for the line above, as it may be a false positive (<span>', $r, '</span>); please check it yourself manually!</em></li>';
-							continue;
+							$is_new = $file != $old_file;
+							$old_file = $file;
+							$func_line = substr_count(substr($php, 0, strpos($php, $matches[0][$key])), "\n");
+							$glob_line = substr_count(substr($matches[3][$key], 0, strpos($matches[3][$key], $test_me)), "\n");
+							echo '<li class="unused', $is_new ? ' new' : '', '">Unused global in <span>', str_replace($root, '', $dir), '/<span class="file">', $file, ':', $func_line + $glob_line + 3, '</span></span> (', $matches[2][$key], ') -- <span>', $test_me, '</span>';
+							if ($probably_false_positive)
+							{
+								if (!isset($_GET['fixme']))
+									echo '<br><em>The line above might be a false positive (<span>', $r, '</span>); it will be skipped during automatic fixes.</em></li>';
+								else
+									echo '<br><em>Skipping fix for the line above, as it may be a false positive (<span>', $r, '</span>); please check it yourself manually!</em></li>';
+								continue;
+							}
+							echo '</li>';
 						}
+
 						// Add ?fixme to the URL after a dry run. The script will skip anything
 						// that looks suspicious, but you should still make a backup before.
 						if (isset($_GET['fixme']))
 						{
-							$matches[0][$key] = preg_replace(
+							$real_ex = $real_matches[0][$key];
+							$real_matches[0][$key] = preg_replace(
 								'~(?<=[\r\n{])[\t ]*global \\' . $test_me . ';[\r\n]+~',
 								'',
 								preg_replace(
 									'~(, ?\\' . $test_me . '(?![a-zA-Z_])|\\' . $test_me . ', ?)~',
 									'',
-									$matches[0][$key]
+									$real_matches[0][$key]
 								)
 							);
-							$php = str_replace($ex, $matches[0][$key], $php);
-							file_put_contents($dir . '/' . $file, $php);
+							$real_php = str_replace($real_ex, $real_matches[0][$key], $real_php);
+							file_put_contents($dir . '/' . $file, $real_php);
 						}
-						echo '</li>';
 					}
 				}
 			}
@@ -152,21 +183,116 @@ function find_global_problems($real_globals = array(), $dir = '')
 				if ((!isset($there_we_are[0]) || !in_array($real_global, $there_we_are[0])) && preg_match('~\\' . $real_global . '[^a-zA-Z_]~', $val))
 				{
 					// Is it on a line with a comment on it? Probably a false positive... (Unless you're using another instance, but you'll still have to fix manually.)
-					$probably_false_positive = preg_match('~(?:^|[;\r\n}])[\t ]*//[^\r\n]*\\' . $real_global . '[^a-zA-Z_]~', $val, $truc);
-					$probably_false_positive |= preg_match('~(?:^|[;\r\n}])[\t ]*/\*([^*]|\*[^/])*\\' . $real_global . '[^a-zA-Z_]~', $val, $truc);
-					$is_new = $file != $old_file;
-					$old_file = $file;
-					$func_line = substr_count(substr($php, 0, strpos($php, $matches[0][$key])), "\n");
-					$glob_line = substr_count(substr($matches[3][$key], 0, strpos($matches[3][$key], $test_me)), "\n");
-					echo '<li class="undeclared', $is_new ? ' new' : '', '">Undeclared global in <span>', str_replace($root, '', $dir), '/<span class="file">', $file, ':', $func_line + $glob_line + 3, '</span></span> (', $matches[2][$key], ') -- <span>', $real_global, '</span>';
-					if ($probably_false_positive)
+					$in_foreach = preg_match('~foreach[\s(].*?\bas\b\s*(?:[^)=>]+=>\s*)?\\' . $real_global . '[^a-zA-Z_]~', $val);
+					$in_params = preg_match('~^\s*\((?:[^)]+[,\s])?\s*\\' . $real_global . '[^a-zA-Z_]~', $val);
+					$in_list = preg_match('~\slist\s*\((?:[^)]+[,\s])?\s*\\' . $real_global . '[^a-zA-Z_]~', $val);
+					$in_assign = preg_match('~\\' . $real_global . '\s*=[^=]~', $val);
+					$in_arrass = preg_match('~\\' . $real_global . '\[[^]]*]\s*=[^=]~', $val);
+					$probably_false_positive = $in_foreach || $in_params || $in_list || $in_assign || $in_arrass;
+
+					if (!$probably_false_positive || !isset($_GET['ignorefp']))
 					{
-						echo '<br><em>The line above might be a false positive (found in a comment).</em></li>';
-						continue;
+						$is_new = $file != $old_file;
+						$old_file = $file;
+						$func_line = substr_count(substr($php, 0, strpos($php, $matches[0][$key])), "\n");
+						$glob_line = substr_count(substr($matches[3][$key], 0, strpos($matches[3][$key], reset($there_we_are[0]))), "\n");
+						echo '<li class="undeclared', $is_new ? ' new' : '', '">Undeclared global in <span>', str_replace($root, '', $dir), '/<span class="file">', $file, ':', $func_line + $glob_line + 3, '</span></span> (', $matches[2][$key], ') -- <span>', $real_global, '</span>';
+						if ($probably_false_positive)
+						{
+							echo '<br><em>The line above might be a false positive (',
+								$in_params ? 'used as a parameter' :
+								($in_assign ? 'initialized within function' :
+								($in_arrass ? 'initialized as implied array within function' :
+								($in_list ? 'initialized in a list() within function' :
+								'found in a ' . ($in_comment ? 'comment' : 'foreach')))), ').</em></li>';
+							continue;
+						}
+						echo '</li>';
 					}
-					echo '</li>';
 				}
 			}
 		}
 	}
+}
+
+// This is a very, very slow function. But it's needed for best results.
+function clean_me_up($php)
+{
+	// List of characters we'll be looking for.
+	$search_for = array('/*', '//', "'", '"');
+	$pos = 0;
+
+	while (true)
+	{
+		$next = find_next($php, $pos, $search_for);
+		if ($next === false)
+			return $php;
+
+		$look_for = $php[$next];
+		if ($look_for === '/')
+		{
+			if ($php[$next + 1] === '/') // Remove //
+				$look_for = array("\r", "\n", "\r\n");
+			else // Remove /* ... */
+				$look_for = '*/';
+		}
+		// We can't skip double quotes because they might hold parsable variables.
+		// So, we'll just find the end of that string, and then skip to the rest.
+		elseif ($look_for == '"')
+		{
+			$next = find_next($php, $next + 1, '"');
+			if ($next === false)
+				return $php;
+			$pos = $next + 1;
+			continue;
+		}
+
+		$end = find_next($php, $next + 1, $look_for);
+		if ($end === false)
+		{
+			$php = substr($php, 0, $next);
+			return $php;
+		}
+		else
+		{
+			if (!is_array($look_for))
+				$end += strlen($look_for);
+			$temp = substr($php, $next, $end - $next);
+
+			$breaks = substr_count($temp, "\n") + substr_count($temp, "\r") - substr_count($temp, "\r\n");
+			$php = substr_replace($php, str_repeat("\n", $breaks), $next, $end - $next);
+		}
+		$pos = $next + 1;
+	}
+}
+
+function find_next(&$php, $pos, $search_for)
+{
+	if (is_array($search_for))
+	{
+		$positions = array();
+		foreach ((array) $search_for as $item)
+		{
+			$position = strpos($php, $item, $pos);
+			if ($position !== false)
+				$positions[] = $position;
+		}
+		if (empty($positions))
+			return false;
+		$next = min($positions);
+	}
+	else
+	{
+		$next = strpos($php, $search_for, $pos);
+		if ($next === false)
+			return false;
+	}
+
+	$check_before = $next;
+	$escaped = false;
+	while (--$check_before >= 0 && $php[$check_before] == '\\')
+		$escaped = !$escaped;
+	if ($escaped)
+		return find_next($php, ++$next, $search_for);
+	return $next;
 }


### PR DESCRIPTION
...ill remove comments (// and /*), as well as strings (single quotes only, and will skip double quotes), which would be worth an extra script file just by itself (I'll probably split it eventually.) In order to ensure it's done properly, the script has to spend a long time on this, making it up to 5 or 10 times slower than before. But, hey, less false positives is better!

@ Note that due to this change, the fixme option is likely to be totally broken. I tried to ensure it wasn't, but I can't say for sure, and will need to test.
- Added an ignorefp option, to prevent the script from showing potential false positives. If you're fixing files manually, this could be a blessing.
- Added more false positive detections for undeclared globals: variables declared in function params, in foreach() loops, in list() calls, and declared as an implied array by assignment. Removed 'found in a comment' false positive, since that is no longer an issue.
- Slight cosmetic improvements. I still need to add some congratulations if your code shows no signs of a global problem.
- Adding a time limit, if PHP allows it.
- Adding links to the couple of non-threatening options, noclean and ignorefp.
- Adding $modSettings to the list of globals to look for. This is a SMF global, not used in Wedge, but whatever.

! Cache folder shouldn't be checked.

Signed-off-by: Nao nao@wedge
